### PR TITLE
Oceanography sources in NetCDF

### DIFF
--- a/formats/Copernicus_Ocean_Altimetry.json
+++ b/formats/Copernicus_Ocean_Altimetry.json
@@ -1,0 +1,37 @@
+{
+  "description" : "Collection format for Delayed Time merged all satellites Global Ocean Gridded SSALTO/DUACS",
+  "tags" : ["Copernicus", "SSH", "Sea surface height", "altimetry", "Geostrophic velocity", "Sea level anomaly"],
+  "subdatasets" : true,
+  "srs" : "EPSG:4326",
+  "pattern" : ".*\\.nc.*",
+  "images" : {
+    "pattern" : ".*NETCDF:\"(.+)\\.nc.*"
+  },
+  "datetime" : {
+    "pattern" : ".*dt_global_allsat_phy_l4.*([0-9]{8}).*",
+    "format" : "%Y%m%d"
+  },
+  "bands" : {
+    "ugosa" : {
+      "pattern" : ".+ugosa.*"
+    },
+    "adt" : {
+      "pattern" : ".+adt.*"
+    },
+    "ugos" : {
+      "pattern" : ".+ugos.*"
+    },
+    "sla" : {
+      "pattern" : ".+sla.*"
+    },
+    "vgos" : {
+      "pattern" : ".+vgos.*"
+    },
+    "vgosa" : {
+      "pattern" : ".+vgosa.*"
+    },
+    "err" : {
+      "pattern" : ".+err.*"
+    }
+  }
+}

--- a/formats/GHRSST_Sea_Surface_temperature.json
+++ b/formats/GHRSST_Sea_Surface_temperature.json
@@ -1,0 +1,28 @@
+{
+  "description" : "Collection format for GHRSST a merged, multi-sensor L4 Foundation SST analysis product from JPL.",
+  "tags" : ["oceans", "temperature", "SST", "JPL", "GHRSST"],
+  "subdatasets" : true,
+  "srs" : "EPSG:4326",
+  "pattern" : ".*\\.nc.*",
+  "images" : {
+    "pattern" : ".*NETCDF:\"(.+)\\.nc.*"
+  },
+  "datetime" : {
+    "pattern" : ".*([0-9]{8})090000-JPL-L4_GHRSST-SSTfnd-MUR-GLOB.*",
+    "format" : "%Y%m%d"
+  },
+  "bands" : {
+      "analysed_sst" : {
+      "pattern" : ".+analysed_sst.*"
+    },
+    "analysis_error" : {
+      "pattern" : ".+analysis_error.*"
+    },
+    "mask" : {
+      "pattern" : ".+mask.*"
+    },
+    "sea_ice_fraction" : {
+      "pattern" : ".+sea_ice_fraction.*"
+    }
+  }
+}

--- a/formats/SMAP_Sea_Surface_Salinity_8day.json
+++ b/formats/SMAP_Sea_Surface_Salinity_8day.json
@@ -1,0 +1,34 @@
+{
+  "description" : "Collection format for Remote Sensing Systems SMAP Level 3 Sea Surface Salinity Standard Mapped Image 8day running",
+  "tags" : ["SURFACE SALINITY", "SALINITY", "SMAP", "NASA", "RSS"],
+  "subdatasets" : true,
+  "srs" : "EPSG:4326",
+  "pattern" : ".*\\.nc.*",
+  "images" : {
+    "pattern" : ".*NETCDF:\"(.+)\\.nc.*"
+  },
+  "datetime" : {
+    "pattern" : ".*RSS_smap_SSS_L3_8day_running_40km_([0-9]{4}_[0-9]{3}).*",
+    "format" : "%Y_%j"
+  },
+  "bands" : {
+      "nobs" : {
+      "pattern" : ".+nobs.*"
+    },
+    "sss_smap" : {
+      "pattern" : ".+sss_smap.*"
+    },
+    "sss_ref" : {
+      "pattern" : ".+sss_ref.*"
+    },
+    "gland" : {
+      "pattern" : ".+gland.*"
+    },
+    "gice" : {
+      "pattern" : ".+gice.*"
+    },
+    "surtep" : {
+      "pattern" : ".+surtep.*"
+    }
+  }
+}

--- a/formats/SMAP_Sea_Surface_Salinity_8day.json
+++ b/formats/SMAP_Sea_Surface_Salinity_8day.json
@@ -1,5 +1,5 @@
 {
-  "description" : "Collection format for Remote Sensing Systems SMAP Level 3 Sea Surface Salinity Standard Mapped Image 8day running",
+  "description" : "Collection format for Remote Sensing Systems SMAP Sea Surface Height L4 product and derived variables Level 3 Sea Surface Salinity Standard Mapped Image 8day running",
   "tags" : ["SURFACE SALINITY", "SALINITY", "SMAP", "NASA", "RSS"],
   "subdatasets" : true,
   "srs" : "EPSG:4326",


### PR DESCRIPTION
Here are three sources, each use the global 'EPSG:4326' property in the config. 

I include links to our config listings in the [bowerbird](https://github.com/ropensci/bowerbird) system

-  [Copernicus_Ocean_Altimetry.json](https://github.com/AustralianAntarcticDivision/blueant#cmems-global-gridded-ssh-reprocessed-1993-ongoing)
- [GHRSST_Sea_Surface_temperature.json](https://github.com/AustralianAntarcticDivision/blueant#ghrsst-level-4-mur-global-foundation-sst-v41)
- **SMAP_Sea_Surface_Salinity_8day.json** - this one doesn't have a listing on our sites, but we have the config in our local admin (it may be discontinued, need to check)

(In time I hope to augment these with tools to download the files using bowerbird, and have some kind of link between our ID and these json file names)